### PR TITLE
Filter example content via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Hi-perfomance, SEO&AI-SEO optimised
 
-
 [![Deploy to Netlify Button](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/dashapps/maugli-astro-theme)
 
 ## Getting started
@@ -29,21 +28,24 @@ Hi-perfomance, SEO&AI-SEO optimised
 
 3. **Build the project**
 
-   ```bash
-   npm run build
-   ```
+```bash
+ npm run build
+```
+
+If you want to hide the example content included with this theme, set
+`showExamples: false` in `src/config/maugli.config.ts`. Example files are
+marked with `isExample: true` in their frontmatter.
 
 ### Useful npm scripts
 
-| Script             | Description                                |
-|--------------------|--------------------------------------------|
-| `npm run dev`      | Start local dev server                     |
-| `npm start`        | Alias for `npm run dev`                    |
-| `npm run build`    | Format content then create production build |
-| `npm run typograf` | Run typograf on all posts                   |
-| `npm run astro`    | Access the Astro CLI                        |
-| `npm run featured:add <slug>` | Mark a post as featured           |
-| `npm run featured:remove <slug>` | Remove featured mark from a post |
-| `npm run featured:list` | List all featured posts                 |
-| `npm run upgrade` | Manually update `maugli.config.ts`          |
-
+| Script                           | Description                                 |
+| -------------------------------- | ------------------------------------------- |
+| `npm run dev`                    | Start local dev server                      |
+| `npm start`                      | Alias for `npm run dev`                     |
+| `npm run build`                  | Format content then create production build |
+| `npm run typograf`               | Run typograf on all posts                   |
+| `npm run astro`                  | Access the Astro CLI                        |
+| `npm run featured:add <slug>`    | Mark a post as featured                     |
+| `npm run featured:remove <slug>` | Remove featured mark from a post            |
+| `npm run featured:list`          | List all featured posts                     |
+| `npm run upgrade`                | Manually update `maugli.config.ts`          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "maugli-blog",
             "version": "1.0.0",
+            "hasInstallScript": true,
             "dependencies": {
                 "@astrojs/mdx": "^4.3.0",
                 "@astrojs/rss": "^4.0.11",
@@ -22,6 +23,8 @@
                 "remark-slug": "^7.0.1",
                 "sharp": "^0.34.2",
                 "tailwindcss": "^4.0.17",
+                "ts-node": "^10.9.2",
+                "tsx": "^4.20.3",
                 "typograf": "^7.4.4"
             },
             "devDependencies": {
@@ -1779,6 +1782,28 @@
                 "fontkit": "^2.0.2"
             }
         },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
         "node_modules/@emnapi/runtime": {
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
@@ -3463,6 +3488,30 @@
                 "vite": "^5.2.0 || ^6 || ^7"
             }
         },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "license": "MIT"
+        },
         "node_modules/@types/debug": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3598,6 +3647,18 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/ajv": {
@@ -4945,6 +5006,12 @@
                 "url": "https://opencollective.com/core-js"
             }
         },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "license": "MIT"
+        },
         "node_modules/cross-fetch": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -5947,6 +6014,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+            "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/github-slugger": {
@@ -7509,6 +7588,12 @@
                 "@babel/types": "^7.25.4",
                 "source-map-js": "^1.2.0"
             }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "license": "ISC"
         },
         "node_modules/markdown-extensions": {
             "version": "2.0.0",
@@ -9800,6 +9885,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/restructure": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
@@ -10690,6 +10784,64 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ts-node/node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "license": "MIT"
+        },
+        "node_modules/ts-node/node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/tsconfck": {
             "version": "3.1.6",
             "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -10715,6 +10867,25 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/tsx": {
+            "version": "4.20.3",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+            "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.25.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
         },
         "node_modules/type-fest": {
             "version": "4.41.0",
@@ -11264,6 +11435,12 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "license": "MIT"
         },
         "node_modules/vfile": {
@@ -12004,6 +12181,15 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
         "remark-slug": "^7.0.1",
         "sharp": "^0.34.2",
         "tailwindcss": "^4.0.17",
+        "ts-node": "^10.9.2",
+        "tsx": "^4.20.3",
         "typograf": "^7.4.4"
     },
     "devDependencies": {

--- a/src/components/ArticleMeta.astro
+++ b/src/components/ArticleMeta.astro
@@ -1,5 +1,6 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content';
+import { type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../utils/content-loader';
 import { maugliConfig } from '../config/maugli.config';
 import { LANGUAGES } from '../i18n/languages';
 import FormattedDate from './FormattedDate.astro';
@@ -32,7 +33,7 @@ const { publishDate, readingTime = '5', post, author, authorImage, class: classN
 
 let authors = [];
 try {
-    authors = await getCollection('authors');
+    authors = await getFilteredCollection('authors');
 } catch (e) {
     console.warn('Не удалось загрузить коллекцию авторов:', e);
 }

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getFilteredCollection } from '../utils/content-loader';
 import { maugliConfig } from '../config/maugli.config';
 import { getPostsByAuthor } from '../utils/data-utils';
 import AuthorLinksGroup from './AuthorLinksGroup.astro';
@@ -33,7 +33,7 @@ const { name, position, description, avatar, socials, slug } = author;
 // Получаем количество статей автора через getPostsByAuthor
 let posts: import('astro:content').CollectionEntry<'blog'>[] = [];
 try {
-    posts = await getCollection('blog');
+    posts = await getFilteredCollection('blog');
 } catch (e) {
     posts = [];
 }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getFilteredCollection } from '../utils/content-loader';
 import siteConfig from '../data/site-config.ts';
 import '../styles/global.css';
 // Определи тип выше:
@@ -68,7 +68,7 @@ function formatCanonicalURL(url: string | URL) {
 
 let authors = [];
 try {
-    authors = await getCollection('authors');
+    authors = await getFilteredCollection('authors');
 } catch (e) {
     console.warn('Не удалось загрузить коллекцию авторов:', e);
 }

--- a/src/components/RubricCard.astro
+++ b/src/components/RubricCard.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getFilteredCollection } from '../utils/content-loader';
 import { maugliConfig } from '../config/maugli.config';
 import { slugify } from '../utils/common-utils';
 import { getPostsByTag } from '../utils/data-utils';
@@ -45,7 +45,7 @@ const slug = slugify(title);
 let postCount = 0;
 let lastPublishDate = '';
 try {
-    const posts = await getCollection('blog');
+    const posts = await getFilteredCollection('blog');
     const rubricPosts = getPostsByTag(posts, slug);
     postCount = rubricPosts.length;
     if (postCount > 0) {

--- a/src/pages/authors/[...page].astro
+++ b/src/pages/authors/[...page].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPathsOptions, Page } from 'astro';
-import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import { getEntry, type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import AuthorCard from '../../components/AuthorCard.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import InfoCard from '../../components/InfoCard.astro';
@@ -15,7 +16,7 @@ const lang: string = typeof maugliConfig.defaultLang === 'string' && dicts[maugl
 const dict = dicts[lang] || dicts['en'];
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
-    const authorsCollection = await getCollection('authors');
+    const authorsCollection = await getFilteredCollection('authors');
     // Сортируем авторов по имени в алфавитном порядке
     const authors = authorsCollection.sort((a, b) => a.data.name.localeCompare(b.data.name, 'ru'));
     return paginate(authors, { pageSize: 4 }); // 4 автора на страницу для красивой сетки 2x2
@@ -25,15 +26,9 @@ type Props = { page: Page<CollectionEntry<'authors'>> };
 
 const { page } = Astro.props;
 let authors = page.data;
-if (!maugliConfig.showExamples) {
-    authors = authors.filter((author) => !author.data.isExample);
-}
 
 // Получаем все статьи
-let allPosts = await getCollection('blog');
-if (!maugliConfig.showExamples) {
-    allPosts = allPosts.filter((post) => !post.data.isExample);
-}
+let allPosts = await getFilteredCollection('blog');
 
 // Фильтрация авторов по наличию статей, если showAuthorsWithoutArticles === false
 if (maugliConfig.showAuthorsWithoutArticles === false) {

--- a/src/pages/authors/[id].astro
+++ b/src/pages/authors/[id].astro
@@ -1,5 +1,6 @@
 ---
-import { type CollectionEntry, getCollection, render } from 'astro:content';
+import { type CollectionEntry, render } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import PostPreview from '../../components/PostPreview.astro';
 import Subscribe from '../../components/Subscribe.astro';
@@ -17,7 +18,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getAllTags, getPostsByTag, sortItemsWithFeaturedFirst } from '../../utils/data-utils';
 
 export async function getStaticPaths() {
-    const authors = await getCollection('authors');
+    const authors = await getFilteredCollection('authors');
     return authors.map((author) => ({
         params: { id: author.id },
         props: { author }
@@ -31,10 +32,7 @@ const { name, position, description, avatar, socials, seo } = author.data;
 const { Content } = await render(author);
 
 // Получаем все статьи блога
-let allPosts = await getCollection('blog');
-if (!maugliConfig.showExamples) {
-    allPosts = allPosts.filter((post) => !post.data.isExample);
-}
+let allPosts = await getFilteredCollection('blog');
 
 // Фильтруем статьи этого автора (с учетом дефолтного автора)
 const authorPosts = allPosts

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPathsOptions, Page } from 'astro';
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import Pagination from '../../components/Pagination.astro';
 import PostPreview from '../../components/PostPreview.astro';
 import Subscribe from '../../components/Subscribe.astro';
@@ -11,10 +12,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getAllTags, getPostsByTag, sortItemsWithFeaturedFirst } from '../../utils/data-utils';
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
-    let posts = (await getCollection('blog')).sort(sortItemsWithFeaturedFirst);
-    if (!maugliConfig.showExamples) {
-        posts = posts.filter((post) => !post.data.isExample);
-    }
+    let posts = (await getFilteredCollection('blog')).sort(sortItemsWithFeaturedFirst);
     return paginate(posts, { pageSize: siteConfig.postsPerPage || 4 });
 }
 
@@ -24,12 +22,8 @@ const { page } = Astro.props;
 const blog = page.data;
 
 // Получаем все теги с количеством постов и выделяем рубрики
-let allPosts = await getCollection('blog');
-let allRubrics = await getCollection('tags');
-if (!maugliConfig.showExamples) {
-    allPosts = allPosts.filter((post) => !post.data.isExample);
-    allRubrics = allRubrics.filter((tag) => !tag.data.isExample);
-}
+let allPosts = await getFilteredCollection('blog');
+let allRubrics = await getFilteredCollection('tags');
 const rubricSlugs = allRubrics.map((r) => r.data.slug);
 let tagsWithCount = getAllTags(allPosts).map((tag) => ({
     id: tag.id,

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -1,5 +1,6 @@
 ---
-import { type CollectionEntry, getCollection, render } from 'astro:content';
+import { type CollectionEntry, render } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import ArticleMeta from '../../components/ArticleMeta.astro';
 import ContentFooter from '../../components/ContentFooter.astro';
 import HeroImage from '../../components/HeroImage.astro';
@@ -21,7 +22,7 @@ const dict = dicts[lang] || dicts['en'];
 const morePostsTitle = dict.buttons?.morePosts || dicts['en'].buttons.morePosts;
 
 export async function getStaticPaths() {
-    const posts = (await getCollection('blog')).sort(sortItemsByDateDesc);
+    const posts = (await getFilteredCollection('blog')).sort(sortItemsByDateDesc);
     const postCount = posts.length;
     return posts.map((post, index) => ({
         params: { id: post.id },
@@ -54,7 +55,7 @@ const tocItems = headings
 // Получаем картинку для баннера по productID (если есть)
 let bannerImage = { src: '/default.webp', alt: title };
 if (post.data.productID) {
-    const allProducts = await getCollection('products');
+    const allProducts = await getFilteredCollection('products');
     const product = allProducts.find((p) => p.id === post.data.productID);
     if (product && product.data.image) {
         bannerImage = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
-import { getCollection, getEntry } from 'astro:content';
+import { getEntry } from 'astro:content';
+import { getFilteredCollection } from '../utils/content-loader';
 import Button from '../components/Button.astro';
 import InfoCard from '../components/InfoCard.astro';
 import PostPreview from '../components/PostPreview.astro';
@@ -20,17 +21,11 @@ const pages = (dict as any).pages || (fallbackDict as any).pages || {};
 const buttons = (dict as any).buttons || (fallbackDict as any).buttons || {};
 
 // Получаем все посты и показываем первые N постов
-let allPosts = (await getCollection('blog')).sort(sortItemsWithFeaturedFirst);
-if (!maugliConfig.showExamples) {
-    allPosts = allPosts.filter((post) => !post.data.isExample);
-}
+let allPosts = (await getFilteredCollection('blog')).sort(sortItemsWithFeaturedFirst);
 const displayPosts = allPosts.slice(0, siteConfig.postsPerPage || 4);
 
 // Получаем все рубрики
-let allRubrics = await getCollection('tags');
-if (!maugliConfig.showExamples) {
-    allRubrics = allRubrics.filter((tag) => !tag.data.isExample);
-}
+let allRubrics = await getFilteredCollection('tags');
 const rubricSlugs = allRubrics.map((r) => r.data.slug);
 
 // Получаем все теги с количеством постов и флагом рубрики

--- a/src/pages/products/[...page].astro
+++ b/src/pages/products/[...page].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPathsOptions, Page } from 'astro';
-import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import { getEntry, type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import InfoCard from '../../components/InfoCard.astro';
 import Pagination from '../../components/Pagination.astro';
@@ -18,7 +19,7 @@ const productsTitle = maugliConfig.pageTitles?.products?.trim() || dict.pages?.p
 const productsDescription = maugliConfig.productsDescription?.trim() || dict.pages?.products?.description || dicts['en'].pages.products.description;
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
-    const products = (await getCollection('products')).sort((a, b) => {
+    const products = (await getFilteredCollection('products')).sort((a, b) => {
         if (b.data.isFeatured !== a.data.isFeatured) return b.data.isFeatured - a.data.isFeatured;
         return (b.data.publishDate?.getTime?.() || 0) - (a.data.publishDate?.getTime?.() || 0);
     });
@@ -29,9 +30,6 @@ type Props = { page: Page<CollectionEntry<'products'>> };
 
 const { page } = Astro.props;
 let productList = page.data;
-if (!maugliConfig.showExamples) {
-    productList = productList.filter((product) => !product.data.isExample);
-}
 const productsSection = await getEntry('pages', 'products');
 ---
 

--- a/src/pages/products/[id].astro
+++ b/src/pages/products/[id].astro
@@ -1,5 +1,6 @@
 ---
-import { getCollection, render, type CollectionEntry } from 'astro:content';
+import { render, type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import ArticleMeta from '../../components/ArticleMeta.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import ContentFooter from '../../components/ContentFooter.astro';
@@ -22,7 +23,7 @@ const articlesByTag = dict.pages?.productsId?.articlesByTag || dicts['en'].pages
 const casesByTag = dict.pages?.productsId?.casesByTag || dicts['en'].pages.productsId.casesByTag;
 
 export async function getStaticPaths() {
-    const products = (await getCollection('products')).sort(sortItemsByDateDesc);
+    const products = (await getFilteredCollection('products')).sort(sortItemsByDateDesc);
     return products.map((product) => ({
         params: { id: product.id },
         props: { product }
@@ -50,8 +51,8 @@ const tocItems = headings
     }));
 
 // Получаем связанные статьи (blog) и кейсы (projects), где productID совпадает с productID продукта
-const relatedPosts = (await getCollection('blog')).filter((post) => post.data.productID === product.data.productID);
-const relatedProjects = (await getCollection('projects')).filter((project) => project.data.productID === product.data.productID);
+const relatedPosts = (await getFilteredCollection('blog')).filter((post) => post.data.productID === product.data.productID);
+const relatedProjects = (await getFilteredCollection('projects')).filter((project) => project.data.productID === product.data.productID);
 
 // Сортировка: сначала featured, потом по дате
 const sortByFeaturedAndDate = (a, b) => {

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPathsOptions, Page } from 'astro';
-import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import { getEntry, type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import InfoCard from '../../components/InfoCard.astro';
 import Pagination from '../../components/Pagination.astro';
@@ -14,7 +15,7 @@ import { slugify } from '../../utils/common-utils';
 import { sortItemsByDateDesc } from '../../utils/data-utils';
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
-    const projects = (await getCollection('projects')).sort(sortItemsByDateDesc);
+    const projects = (await getFilteredCollection('projects')).sort(sortItemsByDateDesc);
     return paginate(projects, { pageSize: siteConfig.projectsPerPage || 6 });
 }
 
@@ -22,11 +23,7 @@ type Props = { page: Page<CollectionEntry<'projects'>> };
 
 const { page } = Astro.props;
 let portfolio = page.data;
-let allProjects = await getCollection('projects');
-if (!maugliConfig.showExamples) {
-    portfolio = portfolio.filter((project) => !project.data.isExample);
-    allProjects = allProjects.filter((project) => !project.data.isExample);
-}
+let allProjects = await getFilteredCollection('projects');
 // Получаем все уникальные теги проектов
 const allTags = [...new Set(allProjects.flatMap((project) => project.data.tags || []))];
 const tagsWithCount = allTags.map((tag) => ({

--- a/src/pages/tags/[id]/[...page].astro
+++ b/src/pages/tags/[id]/[...page].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPathsOptions, Page } from 'astro';
-import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import { getEntry, type CollectionEntry } from 'astro:content';
+import { getFilteredCollection } from '../../../utils/content-loader';
 import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import Pagination from '../../../components/Pagination.astro';
 import PostPreview from '../../../components/PostPreview.astro';
@@ -13,7 +14,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { getAllTags, getPostsByTag, sortItemsWithFeaturedFirst } from '../../../utils/data-utils';
 
 export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
-    const posts = (await getCollection('blog')).sort(sortItemsWithFeaturedFirst);
+    const posts = (await getFilteredCollection('blog')).sort(sortItemsWithFeaturedFirst);
     const tags = getAllTags(posts);
 
     return tags.flatMap((tag) => {
@@ -30,9 +31,9 @@ type Props = { page: Page<CollectionEntry<'blog'>> };
 const { page } = Astro.props;
 const blog = page.data;
 const params = Astro.params;
-const allPosts = await getCollection('blog');
+const allPosts = await getFilteredCollection('blog');
 const allTags = getAllTags(allPosts);
-const allRubrics = await getCollection('tags');
+const allRubrics = await getFilteredCollection('tags');
 const currentTag = allTags.find((tag) => tag.id === params.id);
 
 // Получаем все теги с количеством постов для TagsSection

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,5 +1,6 @@
 ---
-import { getCollection, getEntry } from 'astro:content';
+import { getEntry } from 'astro:content';
+import { getFilteredCollection } from '../../utils/content-loader';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import InfoCard from '../../components/InfoCard.astro';
 import RubricCard from '../../components/RubricCard.astro';
@@ -11,10 +12,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { slugify } from '../../utils/common-utils';
 import { getAllTags, getPostsByTag, sortItemsByDateDesc } from '../../utils/data-utils';
 
-let posts = (await getCollection('blog')).sort(sortItemsByDateDesc);
-if (!maugliConfig.showExamples) {
-    posts = posts.filter((post) => !post.data.isExample);
-}
+let posts = (await getFilteredCollection('blog')).sort(sortItemsByDateDesc);
 const tags = getAllTags(posts).sort((tagA, tagB) => {
     const postCountTagA = getPostsByTag(posts, tagA.id).length;
     const postCountTagB = getPostsByTag(posts, tagB.id).length;
@@ -22,10 +20,7 @@ const tags = getAllTags(posts).sort((tagA, tagB) => {
 });
 
 // Получаем все mdx-файлы рубрик
-let allRubricFiles = await getCollection('tags');
-if (!maugliConfig.showExamples) {
-    allRubricFiles = allRubricFiles.filter((tag) => !tag.data.isExample);
-}
+let allRubricFiles = await getFilteredCollection('tags');
 const rubricSlugs = allRubricFiles.map((r) => r.data.slug);
 const rubricMeta = Object.fromEntries(allRubricFiles.map((r) => [r.data.slug, r]));
 

--- a/src/utils/content-loader.ts
+++ b/src/utils/content-loader.ts
@@ -1,0 +1,14 @@
+import { getCollection, type CollectionEntry, type AnyEntryMap } from 'astro:content';
+import { maugliConfig } from '../config/maugli.config';
+
+/**
+ * Load a collection and filter out demo/example content when showExamples is disabled.
+ * @param name Name of the collection
+ */
+export async function getFilteredCollection<C extends keyof AnyEntryMap>(name: C): Promise<CollectionEntry<C>[]> {
+    const items = await getCollection(name);
+    if (maugliConfig.showExamples) {
+        return items as CollectionEntry<C>[];
+    }
+    return items.filter((item: any) => !item.data.isExample) as CollectionEntry<C>[];
+}

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,46 +1,43 @@
-import { getCollection } from 'astro:content';
+import { getFilteredCollection } from './content-loader';
 
 /**
  * Получает featured посты для отображения на главной странице
  */
 export async function getFeaturedPosts() {
-  try {
-    const allPosts = await getCollection('blog');
-    return allPosts
-      .filter(post => post.data.isFeatured)
-      .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
-      .slice(0, 3); // Максимум 3 featured поста
-  } catch (error) {
-    console.error('Ошибка при получении featured постов:', error);
-    return [];
-  }
+    try {
+        const allPosts = await getFilteredCollection('blog');
+        return allPosts
+            .filter((post) => post.data.isFeatured)
+            .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
+            .slice(0, 3); // Максимум 3 featured поста
+    } catch (error) {
+        console.error('Ошибка при получении featured постов:', error);
+        return [];
+    }
 }
 
 /**
  * Получает все посты (не featured) для отображения в блоге
  */
 export async function getAllPosts() {
-  try {
-    const allPosts = await getCollection('blog');
-    return allPosts
-      .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
-  } catch (error) {
-    console.error('Ошибка при получении постов:', error);
-    return [];
-  }
+    try {
+        const allPosts = await getFilteredCollection('blog');
+        return allPosts.sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
+    } catch (error) {
+        console.error('Ошибка при получении постов:', error);
+        return [];
+    }
 }
 
 /**
  * Получает только обычные посты (не featured)
  */
 export async function getRegularPosts() {
-  try {
-    const allPosts = await getCollection('blog');
-    return allPosts
-      .filter(post => !post.data.isFeatured)
-      .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
-  } catch (error) {
-    console.error('Ошибка при получении обычных постов:', error);
-    return [];
-  }
+    try {
+        const allPosts = await getFilteredCollection('blog');
+        return allPosts.filter((post) => !post.data.isFeatured).sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
+    } catch (error) {
+        console.error('Ошибка при получении обычных постов:', error);
+        return [];
+    }
 }

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -1,5 +1,5 @@
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
+import { getFilteredCollection } from './content-loader';
 import siteConfig from '../data/site-config';
 import { sortItemsByDateDesc } from './data-utils';
 
@@ -8,7 +8,7 @@ import { sortItemsByDateDesc } from './data-utils';
  * This helper can be used in API routes or build scripts.
  */
 export async function generateBlogRss(context: { site: string }) {
-    const posts = (await getCollection('blog')).sort(sortItemsByDateDesc);
+    const posts = (await getFilteredCollection('blog')).sort(sortItemsByDateDesc);
     return rss({
         title: siteConfig.title,
         description: siteConfig.description,

--- a/tests/examplesFilter.demo.mjs
+++ b/tests/examplesFilter.demo.mjs
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+import path from 'path';
+import yaml from 'js-yaml';
+import { maugliConfig } from '../src/config/maugli.config.ts';
+
+async function loadFiles(dir) {
+    const files = await fs.readdir(dir);
+    const result = [];
+    for (const file of files) {
+        const content = await fs.readFile(path.join(dir, file), 'utf8');
+        const match = content.match(/^---\n([\s\S]*?)\n---/);
+        let data = {};
+        if (match) {
+            data = yaml.load(match[1]);
+        }
+        const isExample = !!data.isExample;
+        if (maugliConfig.showExamples || !isExample) {
+            result.push(file);
+        }
+    }
+    return result;
+}
+
+async function run() {
+    maugliConfig.showExamples = false;
+    const posts = await loadFiles(path.join('src', 'content', 'blog'));
+    console.log('Blog posts after filtering:', posts);
+}
+run();

--- a/tests/examplesFilter.test.ts
+++ b/tests/examplesFilter.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { maugliConfig } from '../src/config/maugli.config';
+import { getFilteredCollection } from '../src/utils/content-loader';
+
+async function run() {
+    maugliConfig.showExamples = false;
+    const blog = await getFilteredCollection('blog');
+    assert.ok(
+        blog.every((p) => !(p as any).data.isExample),
+        'Blog examples should be filtered'
+    );
+    const authors = await getFilteredCollection('authors');
+    assert.ok(
+        authors.every((a) => !(a as any).data.isExample),
+        'Author examples should be filtered'
+    );
+    const products = await getFilteredCollection('products');
+    assert.ok(
+        products.every((p) => !(p as any).data.isExample),
+        'Product examples should be filtered'
+    );
+    const projects = await getFilteredCollection('projects');
+    assert.ok(
+        projects.every((p) => !(p as any).data.isExample),
+        'Project examples should be filtered'
+    );
+    console.log('Example filtering works.');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add `getFilteredCollection` utility that hides files with `isExample: true`
- use the new helper across pages and components
- document how to disable example content
- add a small demo and test script for filtering

## Testing
- `node --loader ts-node/esm tests/examplesFilter.demo.mjs`

------
https://chatgpt.com/codex/tasks/task_e_688d19207d04832a9c9cba4a9929c834