### PR TITLE
Add init CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Hi-perfomance, SEO&AI-SEO optimised
 
 ## Getting started
 
+To start a new project in an empty folder run:
+
+```bash
+ npx maugli-blog init my-blog
+ cd my-blog
+```
+
 1. **Install dependencies**
 
    ```bash

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,2 +1,9 @@
 #!/usr/bin/env node
-import '../scripts/upgrade-config.js';
+const [, , cmd, target] = process.argv;
+
+if (cmd === 'init') {
+  const mod = await import('./init.js');
+  await mod.default(target);
+} else {
+  await import('../scripts/upgrade-config.js');
+}

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+async function copyItem(item, targetDir) {
+  const src = path.join(rootDir, item);
+  const dest = path.join(targetDir, item);
+  await fs.cp(src, dest, { recursive: true });
+}
+
+async function npmInstall(targetDir) {
+  await new Promise((resolve, reject) => {
+    const child = spawn('npm', ['install'], { cwd: targetDir, stdio: 'inherit' });
+    child.on('close', code => (code === 0 ? resolve() : reject(new Error(`npm install failed with code ${code}`))));
+  });
+}
+
+export default async function init(targetArg) {
+  const target = targetArg || '.';
+  const targetDir = path.resolve(process.cwd(), target);
+  await fs.mkdir(targetDir, { recursive: true });
+  for (const item of ['src', 'public', 'scripts', 'astro.config.mjs']) {
+    await copyItem(item, targetDir);
+  }
+  await npmInstall(targetDir);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  init(process.argv[2]).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add a new `init` command
- run `npm install` in the generated project
- document `npx maugli-blog init`

## Testing
- `npm run build`
- `node bin/index.js init test-init`

------
https://chatgpt.com/codex/tasks/task_e_688d1ec279d4832aac5541be9f66bbdc