### PR TITLE
Add init script to copy package files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Hi-perfomance, SEO&AI-SEO optimised
 
 1. **Install dependencies**
 
+   If you created your project using the provided `init` script, the
+   dependencies are already installed and you can skip this step.
+
    ```bash
    npm install
    ```

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { cpSync, existsSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const templateRoot = path.join(__dirname, '..');
+const targetDir = process.argv[2] ? path.resolve(process.argv[2]) : process.cwd();
+
+function copyItem(item) {
+  const src = path.join(templateRoot, item);
+  const dest = path.join(targetDir, item);
+  cpSync(src, dest, { recursive: true });
+  console.log(`Copied ${item}`);
+}
+
+// Copy package files first so npm install works correctly
+['package.json', 'package-lock.json'].forEach(file => {
+  if (existsSync(path.join(templateRoot, file))) {
+    copyItem(file);
+  }
+});
+
+const items = [
+  'astro.config.mjs',
+  'tsconfig.json',
+  'public',
+  'src',
+  'scripts',
+  'typograf-batch.js',
+  'resize-all.cjs'
+];
+items.forEach(copyItem);
+
+execSync('npm install', { cwd: targetDir, stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- implement `bin/init.js` script
- update README instructions about initial dependencies

## Testing
- `npx tsx tests/examplesFilter.test.ts` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `npm run upgrade`

------
https://chatgpt.com/codex/tasks/task_e_688d239fe0c8832aa87d1d82d4d74440