### PR TITLE
Add update instructions and backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,19 @@ marked with `isExample: true` in their frontmatter.
 | `npm run featured:remove <slug>` | Remove featured mark from a post            |
 | `npm run featured:list`          | List all featured posts                     |
 | `npm run upgrade`                | Manually update `maugli.config.ts`          |
+
+## Updating
+
+Running `npm update` will replace the files in `src/components` and
+`src/layouts` with the latest versions. Your content under `src/content/**`,
+the global stylesheet `src/styles/global.css`, and
+`src/config/maugli.config.ts` are preserved.
+
+Always commit your changes to version control before updating so you can easily
+restore them if needed. Optionally, you can create a backup prior to updating:
+
+```bash
+npm run backup
+npm update
+```
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "featured:add": "node scripts/featured.js add",
     "featured:remove": "node scripts/featured.js remove",
     "featured:list": "node scripts/featured.js list",
+    "backup": "node scripts/backup.js",
     "upgrade": "node scripts/upgrade-config.js",
     "postinstall": "node scripts/upgrade-config.js"
   },

--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+const backupDir = path.join(process.cwd(), `backup-${timestamp}`);
+
+fs.mkdirSync(backupDir, { recursive: true });
+
+const items = [
+  'src/content',
+  'src/styles/global.css',
+  'src/config/maugli.config.ts'
+];
+
+for (const item of items) {
+  const src = path.join(process.cwd(), item);
+  const dest = path.join(backupDir, item);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.cpSync(src, dest, { recursive: true });
+  console.log(`Backed up ${item} to ${dest}`);
+}
+
+console.log(`Backup complete: ${backupDir}`);


### PR DESCRIPTION
## Summary
- document update behaviour in README
- provide `npm run backup` script to save content and config before updating

## Testing
- `npm run build`
- `node scripts/backup.js`

------
https://chatgpt.com/codex/tasks/task_e_688d326e48c0832aaf9ff3d09ba7298b