### PR TITLE
feat: add language selection to init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ cd my-blog
 npm run dev
 ```
 
+To initialize inside the current folder use:
+
+```bash
+npx core-maugli init .
+```
+
+The init script lets you choose a language or pass one with `--lang`. Available codes: `ru`, `en`, `es`, `de`, `pt`, `fr`, `zh`, `ja`.
+
+Example:
+
+```bash
+npx core-maugli init my-blog --lang es
+```
+
+You pick the language only once during project creation; updates won't ask again.
+
 Your blog will be available at `http://localhost:4321/`
 
 1. **Install dependencies**

--- a/src/config/maugli.config.ts
+++ b/src/config/maugli.config.ts
@@ -195,7 +195,7 @@ export const maugliConfig: MaugliConfig = {
   defaultAuthorId: 'default-autor', // Default author id (used if no author is specified). Use the filename of the author .md file without the .md extension
   showAuthorsWithoutArticles: true, // Show authors without articles (default: true)
   showAuthorArticleCount: true, // Show article count for author
-  showLangSwitcher: true, // Show language switcher
+  showLangSwitcher: false, // Show language switcher
   langLinks: {
     ru: 'https://maugli.cfd/ru', // Russian version
     en: 'https://maugli.cfd/en', // English version


### PR DESCRIPTION
## Summary
- allow `init` to accept `--lang` or prompt for language
- set chosen language in `maugli.config.ts` and match `showLangSwitcher`
- document language selection and current-folder init in README

## Testing
- `npm test` *(fails: Unknown file extension ".ts")*
- `npx tsx tests/examplesFilter.test.ts` *(fails: unsupported ESM URL scheme)*

------
https://chatgpt.com/codex/tasks/task_e_688efa78a01c832aabb622e048530889