### PR TITLE
Bump config version to 0.2 for new PWA defaults

### DIFF
--- a/src/config/maugli.config.ts
+++ b/src/config/maugli.config.ts
@@ -1,5 +1,5 @@
 // MAUGLI_CONFIG_VERSION — config version for CLI/automation compatibility
-export const MAUGLI_CONFIG_VERSION = '0.1';
+export const MAUGLI_CONFIG_VERSION = '0.2';
 // Main configuration interface for the Maugli project
 export interface MaugliConfig {
   // Show example/demo content (for CLI/empty blog setup)


### PR DESCRIPTION
## Summary
- bump `MAUGLI_CONFIG_VERSION` to `0.2` so CLI upgrades can merge PWA settings into user configs without overwriting existing values

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_688fb0c9b424832aae0c812da80d74cb