### PR TITLE
Run resize and preview scripts automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     ],
     "scripts": {
         "typograf": "node typograf-batch.js",
-        "dev": "astro dev",
+        "dev": "node resize-all.cjs && node scripts/generate-previews.js && astro dev",
+        "prestart": "node resize-all.cjs && node scripts/generate-previews.js",
         "start": "astro dev",
-        "build": "node typograf-batch.js && node scripts/verify-assets.js && node scripts/generate-previews.js && astro build",
+        "build": "node resize-all.cjs && node typograf-batch.js && node scripts/verify-assets.js && node scripts/generate-previews.js && astro build",
         "test": "node tests/examplesFilter.test.ts",
         "astro": "astro",
         "featured:add": "node scripts/featured.js add",


### PR DESCRIPTION
## Summary
- run `resize-all.cjs` and preview generation before dev/start
- ensure build also runs resizing

## Testing
- `npm test` *(fails: Unknown file extension ".ts")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a83bf65c832aa5fb33e9cfb90ce3