### PR TITLE
feat: optimize card images with pre-generated previews

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,6 +1,9 @@
 ---
 import { maugliConfig } from '../config/maugli.config';
 import FormattedDate from './FormattedDate.astro';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 type Props = {
     href: string;
@@ -33,6 +36,22 @@ const cardImage =
             : maugliConfig.seo.defaultImage);
 const cardImageAlt = seo?.image?.alt || image?.alt || title || 'Изображение';
 
+// Используем уменьшенное превью, если оно существует
+let previewImage;
+if (cardImage) {
+    previewImage = cardImage.replace(/\/([^\/]+)$/, '/previews/$1');
+
+    const __filename = fileURLToPath(import.meta.url);
+    const projectRoot = path.resolve(path.dirname(__filename), '../..');
+    const previewFilePath = path.join(projectRoot, 'public', previewImage.replace(/^\//, ''));
+
+    if (!fs.existsSync(previewFilePath)) {
+        previewImage = undefined;
+    }
+}
+
+const finalImage = previewImage || cardImage;
+
 // Определяем контент для отображения
 const content = excerpt || description;
 ---
@@ -48,9 +67,11 @@ const content = excerpt || description;
         <!-- Изображение -->
         <div class="w-full aspect-[1200/630] bg-[var(--bg-muted)] overflow-hidden relative">
             <img
-                src={cardImage}
+                src={finalImage}
                 alt={cardImageAlt}
                 loading="lazy"
+                width={previewImage ? 400 : undefined}
+                height={previewImage ? 210 : undefined}
                 class="w-full h-full object-cover rounded-custom transition-transform duration-300 group-hover:scale-105"
             />
 


### PR DESCRIPTION
## Summary
- use pre-generated preview images in Card component when available
- add fixed dimensions and fallback logic for card thumbnails

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891bfe99e68832a9358686477a4c4c1