### PR TITLE
feat: resolve image resize from node modules

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'astro/config';
 import remarkSlug from 'remark-slug';
 import { imagetools } from 'vite-imagetools';
 import { VitePWA } from 'vite-plugin-pwa';
-import imageResize from './astro-image-resize.mjs';
+import imageResize from 'core-maugli/astro-image-resize.mjs';
 import { maugliConfig } from './src/config/maugli.config';
 import siteConfig from './src/data/site-config';
 import customSlugify from './src/utils/remark-slugify';


### PR DESCRIPTION
## Summary
- resolve image resize plugin from node_modules instead of local file

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*
- `npm run build:fast`

------
https://chatgpt.com/codex/tasks/task_e_68991f54af18832a92137f093292345f