### PR TITLE
Verify npm package contents before publish

### DIFF
--- a/github/workflows/publish.yml
+++ b/github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build --if-present
+      - run: npm run verify-pack
 
       - name: Publish to npm
         env:

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
         "set-force-update": "node scripts/set-force-update.js",
         "postinstall": "node scripts/upgrade-config.js && node scripts/setup-user-images.js",
         "generate-previews": "node scripts/generate-previews.js",
-        "generate-netlify": "node scripts/generate-netlify-config.js"
+        "generate-netlify": "node scripts/generate-netlify-config.js",
+        "verify-pack": "node scripts/verify-pack.js"
     },
+    "prepublishOnly": "npm run verify-pack",
     "dependencies": {
         "@astrojs/mdx": "^4.3.0",
         "@astrojs/rss": "^4.0.11",

--- a/scripts/verify-pack.js
+++ b/scripts/verify-pack.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
+
+// Run `npm pack --dry-run` and capture JSON output describing package contents
+const env = { ...process.env, npm_config_loglevel: 'error' };
+const raw = execSync('npm pack --dry-run --json', { encoding: 'utf8', env });
+// npm may print warnings before JSON; find the JSON start
+const jsonStart = raw.indexOf('[');
+const info = JSON.parse(raw.slice(jsonStart))[0];
+const files = info.files.map((f) => f.path);
+
+// Build list of expected files based on package.json `files` plus common extras
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const expected = [ ...(pkg.files || []), 'README.md', 'LICENSE' ];
+const missing = [];
+
+for (const entry of expected) {
+  if (entry.includes('*')) {
+    const regex = new RegExp('^' + entry
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/g, '.*'));
+    if (!files.some((f) => regex.test(f))) missing.push(entry);
+    continue;
+  }
+
+  let isDir = false;
+  try {
+    isDir = statSync(entry).isDirectory();
+  } catch {
+    // If local file doesn't exist, we'll report it as missing below
+  }
+
+  if (isDir || entry.endsWith('/')) {
+    const prefix = entry.endsWith('/') ? entry : entry + '/';
+    if (!files.some((f) => f.startsWith(prefix))) missing.push(entry);
+  } else if (!files.includes(entry)) {
+    missing.push(entry);
+  }
+}
+
+if (missing.length > 0) {
+  console.error('Missing required files in npm package:', missing.join(', '));
+  process.exit(1);
+}
+
+console.log('All required package files are present.');


### PR DESCRIPTION
## Summary
- add script to run `npm pack --dry-run` and assert required files are packaged
- wire check into npm `prepublishOnly` and CI workflow

## Testing
- `npm test` (fails: ERR_UNKNOWN_FILE_EXTENSION)
- `npm run verify-pack`


------
https://chatgpt.com/codex/tasks/task_e_689921935438832aada4b4287040a7e0