### PR TITLE
chore: bump version to 1.2.78

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "core-maugli",
-    "version": "1.2.77",
+    "version": "1.2.78",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "core-maugli",
-            "version": "1.2.77",
+            "version": "1.2.78",
             "hasInstallScript": true,
             "license": "GPL-3.0-or-later OR Commercial",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "core-maugli",
     "description": "Astro & Tailwind CSS blog theme for Maugli.",
     "type": "module",
-    "version": "1.2.77",
+    "version": "1.2.78",
     "license": "GPL-3.0-or-later OR Commercial",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary
- bump version to v1.2.78

## Testing
- `npm test` *(fails: Unknown file extension ".ts")*

------
https://chatgpt.com/codex/tasks/task_e_68991c18ee00832aa24e32c931f89826