### PR TITLE
Move publish workflow and add provenance permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*' # Запускать только при пуше тега вида v1.2.3
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Move publish workflow into `.github/workflows`
- Add `contents` and `id-token` permissions for provenance publishing

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689974aaa184832a89381e3aa6564f64