### PR TITLE
chore: remove core-maugli dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "core-maugli",
-  "version": "1.2.79",
+  "version": "1.2.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "core-maugli",
-      "version": "1.2.79",
+      "version": "1.2.80",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later OR Commercial",
       "dependencies": {
@@ -18,7 +18,6 @@
         "@fontsource-variable/newsreader": "^5.2.6",
         "@tailwindcss/vite": "^4.0.17",
         "astro": "^5.5.6",
-        "core-maugli": "^1.2.78",
         "i18next": "^25.3.2",
         "js-yaml": "^4.1.0",
         "marked": "^15.0.7",
@@ -5042,36 +5041,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-maugli": {
-      "version": "1.2.78",
-      "resolved": "https://registry.npmjs.org/core-maugli/-/core-maugli-1.2.78.tgz",
-      "integrity": "sha512-UO5hi7J4ULrBWzw5A3wh2LW+3c/KfJxcSJhC02KJiUD/P5WWHJ2jDPEdOeusM9CiQmAruf21f30GyD4DReN5oA==",
-      "hasInstallScript": true,
-      "license": "GPL-3.0-or-later OR Commercial",
-      "dependencies": {
-        "@astrojs/mdx": "^4.3.0",
-        "@astrojs/rss": "^4.0.11",
-        "@astrojs/sitemap": "^3.4.0",
-        "@fontsource-variable/geologica": "^5.2.6",
-        "@fontsource-variable/inter": "^5.2.5",
-        "@fontsource-variable/newsreader": "^5.2.6",
-        "@tailwindcss/vite": "^4.0.17",
-        "astro": "^5.5.6",
-        "i18next": "^25.3.2",
-        "js-yaml": "^4.1.0",
-        "marked": "^15.0.7",
-        "remark-slug": "^7.0.1",
-        "sharp": "^0.34.2",
-        "tailwindcss": "^4.0.17",
-        "ts-node": "^10.9.2",
-        "tsx": "^4.20.3",
-        "typescript": "^5.9.2",
-        "typograf": "^7.4.4"
-      },
-      "bin": {
-        "core-maugli": "bin/index.js"
       }
     },
     "node_modules/create-require": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "core-maugli",
   "description": "Astro & Tailwind CSS blog theme for Maugli.",
   "type": "module",
-  "version": "1.2.79",
+  "version": "1.2.80",
   "license": "GPL-3.0-or-later OR Commercial",
   "repository": {
     "type": "git",
@@ -57,7 +57,6 @@
     "@fontsource-variable/newsreader": "^5.2.6",
     "@tailwindcss/vite": "^4.0.17",
     "astro": "^5.5.6",
-    "core-maugli": "^1.2.78",
     "i18next": "^25.3.2",
     "js-yaml": "^4.1.0",
     "marked": "^15.0.7",


### PR DESCRIPTION
## Summary
- drop internal `core-maugli` package from dependencies
- bump package version to 1.2.80

## Testing
- `npm test` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `npm publish --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_6899a9c8b7a0832a893ee8e435a5131a