### PR TITLE
Add service worker endpoint and dynamic registration path

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -175,7 +175,7 @@ let defaultAuthorName = defaultAuthor.data.name;
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', async () => {
             try {
-                const registration = await navigator.serviceWorker.register('/sw.js');
+                const registration = await navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`);
                 console.log('SW registered: ', registration);
             } catch (registrationError) {
                 console.log('SW registration failed: ', registrationError);

--- a/src/pages/sw.js.ts
+++ b/src/pages/sw.js.ts
@@ -1,0 +1,6 @@
+import { buildSW } from 'virtual:pwa-register';
+
+export const GET = async () =>
+  new Response(await buildSW(), {
+    headers: { 'Content-Type': 'application/javascript' }
+  });


### PR DESCRIPTION
## Summary
- expose runtime-generated service worker under `sw.js`
- register service worker using `import.meta.env.BASE_URL`

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*
- `node --loader ts-node/esm tests/examplesFilter.test.ts` *(fails: Cannot find module 'src/config/maugli.config')*


------
https://chatgpt.com/codex/tasks/task_e_6899b823e33c832aad349b4255657238