### PR TITLE
feat: run upgrade on version change only

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:ci": "SKIP_VERSION_CHECK=true npm run build",
     "init-netlify": "node scripts/copy-netlify-config.js",
     "set-force-update": "node scripts/set-force-update.js",
-    "postinstall": "node scripts/upgrade-config.js && node scripts/setup-user-images.js",
+    "postinstall": "node scripts/postinstall.js",
     "generate-previews": "node scripts/generate-previews.js",
     "generate-netlify": "node scripts/generate-netlify-config.js",
     "verify-pack": "node scripts/verify-pack.js",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function runUpgrade() {
+    const upgradePath = path.join(__dirname, 'upgrade-config.js');
+    await import(pathToFileURL(upgradePath).href);
+}
+
+async function runSetupImages() {
+    const { setupUserImages } = await import('./setup-user-images.js');
+    await setupUserImages();
+}
+
+async function main() {
+    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8'));
+    const currentVersion = pkg.version;
+
+    const userRoot = process.env.INIT_CWD || process.cwd();
+    const versionFile = path.join(userRoot, '.core-maugli-version');
+
+    let previousVersion = null;
+    try {
+        previousVersion = (await fs.readFile(versionFile, 'utf8')).trim();
+    } catch {}
+
+    if (previousVersion !== currentVersion) {
+        console.log(`Detected core-maugli version change (${previousVersion || 'none'} -> ${currentVersion}).`);
+        await runUpgrade();
+        await fs.writeFile(versionFile, currentVersion, 'utf8');
+    } else {
+        console.log(`core-maugli version ${currentVersion} unchanged, skipping upgrade.`);
+    }
+
+    await runSetupImages();
+}
+
+main().catch((err) => {
+    console.error('Postinstall failed:', err);
+    process.exit(1);
+});

--- a/scripts/upgrade-config.js
+++ b/scripts/upgrade-config.js
@@ -9,17 +9,6 @@ import { fileURLToPath, pathToFileURL } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Импортируем функцию обновления компонентов
-async function importUpdateComponents() {
-  try {
-    const { updateComponents } = await import('./update-components.js');
-    return updateComponents;
-  } catch (error) {
-    console.warn('Could not load update-components.js:', error.message);
-    return null;
-  }
-}
-
 const defaultConfigPath = path.join(__dirname, '../src/config/maugli.config.ts');
 const userRoot = process.env.INIT_CWD || process.cwd();
 const userConfigPath = path.join(userRoot, 'src/config/maugli.config.ts');
@@ -55,14 +44,6 @@ function mergeMissing(target, source) {
 
 async function main() {
     console.log('🔄 Starting Maugli upgrade process...');
-    
-    // Сначала обновляем компоненты
-    const updateComponents = await importUpdateComponents();
-    if (updateComponents) {
-        await updateComponents();
-    }
-    
-    // Затем обновляем конфиг
     const pkg = await loadTsModule(defaultConfigPath);
     const defCfg = pkg.maugliConfig;
     const newVersion = pkg.MAUGLI_CONFIG_VERSION || defCfg.configVersion;


### PR DESCRIPTION
## Summary
- skip postinstall upgrade unless core-maugli package version changed
- drop automatic component updates; `upgrade-config` now only refreshes config
- keep running user image setup after conditional upgrade

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*
- `npx tsx tests/examplesFilter.test.ts` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_6899bc048b30832ab1bae3543fbd53ff