### PR TITLE
feat: support per-post Typograf locale

### DIFF
--- a/src/content/blog/jsonld-guide.md
+++ b/src/content/blog/jsonld-guide.md
@@ -6,6 +6,7 @@ excerpt: >-
 publishDate: 2025-07-20T00:00:00.000Z
 isFeatured: false
 author: dmitry-growth-marketer
+inLanguage: ru
 tags:
   - SEO & AI SEO
   - JSON-LD

--- a/src/content/blog/post-0.md
+++ b/src/content/blog/post-0.md
@@ -6,6 +6,7 @@ excerpt: >-
   технологическая революция!
 tags:
   - Автоматизация бизнеса
+inLanguage: ru
 seo:
   image:
     src: /img/examples/blog/post_1_jsonld_guide.webp

--- a/src/content/blog/post-1-avtomatizaciya-marketinga-kak-ii-osvobozhdaet-predprinimatelei-ot-cifrovogo-rabstva.md
+++ b/src/content/blog/post-1-avtomatizaciya-marketinga-kak-ii-osvobozhdaet-predprinimatelei-ot-cifrovogo-rabstva.md
@@ -6,6 +6,7 @@ excerpt: >-
 publishDate: 2025-05-14T00:00:00.000Z
 isFeatured: false
 author: dmitry-growth-marketer
+inLanguage: ru
 tags:
   - Автоматизация бизнеса
 seo:

--- a/src/content/blog/post-agent-experience-mcp-biznes-v-epohu-ii-agentov.md
+++ b/src/content/blog/post-agent-experience-mcp-biznes-v-epohu-ii-agentov.md
@@ -8,6 +8,7 @@ publishDate: '2025-05-16'
 isFeatured: true
 tags:
   - Индустриальные обзоры
+inLanguage: ru
 seo:
   title: '5 стратегий контент-маркетинга для стартапов: автоматизация и революция'
   description: |

--- a/src/content/blog/test-post-2025-07-11.md
+++ b/src/content/blog/test-post-2025-07-11.md
@@ -28,6 +28,7 @@ seo:
     - '2025'
     - тестирование
 author: Maugli Team
+inLanguage: ru
 isExample: true
 ---
 # Тестовый пост: Революция контента в 2025 году

--- a/typograf-batch.js
+++ b/typograf-batch.js
@@ -2,7 +2,16 @@ import Typograf from 'typograf';
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
 import yaml from 'js-yaml';
 
-const tp = new Typograf({ locale: ['ru', 'en-US'] });
+const localeMap = { ru: 'ru', en: 'en-US', es: 'es', fr: 'fr', de: 'de-DE' };
+const tpCache = {};
+function getTp(lang = 'ru') {
+  const locale = localeMap[lang] || 'ru';
+  if (!tpCache[locale]) {
+    tpCache[locale] = new Typograf({ locale: [locale] });
+  }
+  return tpCache[locale];
+}
+
 const dir = './src/content/blog';
 const cacheFile = './.typograf-cache.json';
 
@@ -26,7 +35,8 @@ readdirSync(dir)
     const data = readFileSync(file, 'utf8');
     const parts = data.split('---');
     if (parts.length < 3) return;
-    let fm = yaml.load(parts[1]);
+    let fm = yaml.load(parts[1]) || {};
+    const tp = getTp(fm.inLanguage);
     if (fm.title) fm.title = tp.execute(fm.title);
     if (fm.description) fm.description = tp.execute(fm.description);
 


### PR DESCRIPTION
## Summary
- add `inLanguage` frontmatter to blog posts
- select Typograf locale from `inLanguage` in typograf-batch.js

## Testing
- `npm run typograf`
- `npm test` *(fails: Unknown file extension ".ts")*
- `npx tsx tests/examplesFilter.test.ts` *(fails: Unsupported ESM URL scheme 'astro:')*


------
https://chatgpt.com/codex/tasks/task_e_6899fc030ecc832ab8d6c75bc7709440