### PR TITLE
Use config locale for Typograf

### DIFF
--- a/typograf-batch.js
+++ b/typograf-batch.js
@@ -2,7 +2,30 @@ import Typograf from 'typograf';
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
 import yaml from 'js-yaml';
 
-const tp = new Typograf({ locale: ['ru', 'en-US'] });
+// Determine locale from Maugli config (single-language site)
+let defaultLang = 'en';
+try {
+    const configRaw = readFileSync('./src/config/maugli.config.ts', 'utf8');
+    const match = configRaw.match(/defaultLang:\s*['"]([a-zA-Z-]+)['"]/);
+    if (match) defaultLang = match[1];
+} catch {
+    // use fallback defaultLang
+}
+
+const langLocaleMap = {
+    en: 'en-US',
+    ru: 'ru',
+    es: 'es',
+    de: 'de',
+    pt: 'pt',
+    fr: 'fr',
+    zh: 'zh',
+    ja: 'ja'
+};
+
+const locale = langLocaleMap[defaultLang] || defaultLang;
+const tp = new Typograf({ locale: [locale] });
+
 const dir = './src/content/blog';
 const cacheFile = './.typograf-cache.json';
 


### PR DESCRIPTION
## Summary
- Determine Typograf locale from `maugli.config.ts`

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*
- `npx tsx tests/examplesFilter.test.ts` *(fails: unsupported ESM URL scheme 'astro:')*


------
https://chatgpt.com/codex/tasks/task_e_6899c0fc7b9c832a8b66b304d2beee17