### PR TITLE
feat: typografize multiple content directories

### DIFF
--- a/typograf-batch.js
+++ b/typograf-batch.js
@@ -1,10 +1,17 @@
 import Typograf from 'typograf';
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
+import path from 'path';
 import yaml from 'js-yaml';
 
 const tp = new Typograf({ locale: ['ru', 'en-US'] });
-const dir = './src/content/blog';
 const cacheFile = './.typograf-cache.json';
+
+// Directories to process are provided via CLI arguments.
+// If none are passed, default collections are used.
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+    dirs.push('./src/content/blog', './src/content/pages', './src/content/projects', './src/content/products', './src/content/tags');
+}
 
 let cache = {};
 if (existsSync(cacheFile)) {
@@ -13,51 +20,60 @@ if (existsSync(cacheFile)) {
 
 let cacheUpdated = false;
 
-readdirSync(dir)
-    .filter((f) => f.endsWith('.md'))
-    .forEach((f) => {
-        const file = dir + '/' + f;
-        const stats = statSync(file);
-        const mtime = stats.mtimeMs;
-
-        // Если не изменялся — скипаем
-        if (cache[f] === mtime) return;
-
-        const data = readFileSync(file, 'utf8');
-        const parts = data.split('---');
-        if (parts.length < 3) return;
-        let fm = yaml.load(parts[1]);
-
-        const typografize = (value) => {
-            if (Array.isArray(value)) {
-                return value.map(typografize);
-            }
-            if (value && typeof value === 'object') {
-                for (const key of Object.keys(value)) {
-                    value[key] = typografize(value[key]);
-                }
-                return value;
-            }
-            if (typeof value === 'string') {
-                if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('/') || !isNaN(Date.parse(value))) {
-                    return value;
-                }
-                return tp.execute(value);
-            }
+const typografize = (value) => {
+    if (Array.isArray(value)) {
+        return value.map(typografize);
+    }
+    if (value && typeof value === 'object') {
+        for (const key of Object.keys(value)) {
+            value[key] = typografize(value[key]);
+        }
+        return value;
+    }
+    if (typeof value === 'string') {
+        if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('/') || !isNaN(Date.parse(value))) {
             return value;
-        };
+        }
+        return tp.execute(value);
+    }
+    return value;
+};
 
-        fm = typografize(fm);
+const processFile = (file) => {
+    const stats = statSync(file);
+    const mtime = stats.mtimeMs;
 
-        const newData = ['---', yaml.dump(fm, { lineWidth: -1, noRefs: true }).trim(), '---', tp.execute(parts.slice(2).join('---'))].join('\n');
+    // Skip if unchanged
+    if (cache[file] === mtime) return;
 
-        writeFileSync(file, newData);
-        cache[f] = mtime;
-        cacheUpdated = true;
-        console.log(`Typografed: ${file}`);
+    const data = readFileSync(file, 'utf8');
+    const parts = data.split('---');
+    if (parts.length < 3) return;
+    let fm = yaml.load(parts[1]);
+    fm = typografize(fm);
+
+    const newData = ['---', yaml.dump(fm, { lineWidth: -1, noRefs: true }).trim(), '---', tp.execute(parts.slice(2).join('---'))].join('\n');
+
+    writeFileSync(file, newData);
+    cache[file] = mtime;
+    cacheUpdated = true;
+    console.log(`Typografed: ${file}`);
+};
+
+const walk = (dir) => {
+    readdirSync(dir, { withFileTypes: true }).forEach((entry) => {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            walk(fullPath);
+        } else if (entry.isFile() && (entry.name.endsWith('.md') || entry.name.endsWith('.mdx'))) {
+            processFile(fullPath);
+        }
     });
+};
 
-// Сохраняем кеш только если были изменения
+dirs.forEach((d) => walk(d));
+
+// Save cache only if updated
 if (cacheUpdated) {
     writeFileSync(cacheFile, JSON.stringify(cache, null, 2));
 }


### PR DESCRIPTION
## Summary
- allow typograf-batch script to accept directories via CLI and default to common content collections
- recursively typografize all `.md` and `.mdx` files across specified directories

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*
- `npx tsx tests/examplesFilter.test.ts` *(fails: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'astro:')*

------
https://chatgpt.com/codex/tasks/task_e_689a0114d178832a9f62008310a8b40d