### PR TITLE
Include authors in typograf directories

### DIFF
--- a/typograf-batch.js
+++ b/typograf-batch.js
@@ -11,7 +11,14 @@ const cacheFile = './.typograf-cache.json';
 // If none are passed, default collections are used.
 const dirs = process.argv.slice(2);
 if (dirs.length === 0) {
-    dirs.push('./src/content/blog', './src/content/pages', './src/content/projects', './src/content/products', './src/content/tags');
+    dirs.push(
+        './src/content/blog',
+        './src/content/pages',
+        './src/content/projects',
+        './src/content/products',
+        './src/content/tags',
+        './src/content/authors'
+    );
 }
 
 


### PR DESCRIPTION
## Summary
- ensure typograf processes author profile content by default

## Testing
- `npm run typograf`
- `npm test` *(fails: Unknown file extension ".ts" for tests/examplesFilter.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689a1051d320832a8a57de317d603e39