### PR TITLE
fix: update typograf cache after file write

### DIFF
--- a/typograf-batch.js
+++ b/typograf-batch.js
@@ -66,7 +66,8 @@ const processFile = (file) => {
     const newData = ['---', yaml.dump(fm, { lineWidth: -1, noRefs: true }).trim(), '---', tp.execute(parts.slice(2).join('---'))].join('\n');
 
     writeFileSync(file, newData);
-    cache[file] = mtime;
+    const newMtime = statSync(file).mtimeMs;
+    cache[file] = newMtime;
     cacheUpdated = true;
     console.log(`Typografed: ${file}`);
 };


### PR DESCRIPTION
## Summary
- ensure typograf cache stores fresh mtime after modifying files

## Testing
- `npm test` (fails: Unknown file extension ".ts")
- `npx tsx tests/examplesFilter.test.ts` (fails: Unsupported ESM URL scheme 'astro:')
- `npm run typograf`
- `npm run typograf`

------
https://chatgpt.com/codex/tasks/task_e_689a13986b24832ab19887ba98f361db